### PR TITLE
Fixed issue #2 - added missing publickeytoken to RestSharp reference.

### DIFF
--- a/Unifonic.API.Net40/Unifonic.API.Net40.csproj
+++ b/Unifonic.API.Net40/Unifonic.API.Net40.csproj
@@ -35,7 +35,7 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net4\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/Unifonic.API/Unifonic.API.csproj
+++ b/Unifonic.API/Unifonic.API.csproj
@@ -46,7 +46,7 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>


### PR DESCRIPTION
This will allow use bindingRedirect for RestSharp in projects using Unifonic.API library.